### PR TITLE
rpush + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Redis server clone (Coding Challenges). Tokio-based async TCP server on `127.0.0.1:6379` speaking the RESP protocol. See `JOURNAL.md` for design history and rationale.
+
+## Commands
+
+Always run cargo in release mode.
+
+- Build: `cargo build --release`
+- Run server: `cargo run --release` (set `RUST_LOG=trace|warn|error` for logs)
+- Test all: `cargo test --release`
+- Test single: `cargo test --release <name>` (e.g. `cargo test --release execute_lpush_ok`)
+- Test one module: `cargo test --release cmd::execution::list`
+- Lint: `cargo clippy --release`
+- Bench: `cargo bench`
+
+## Architecture
+
+Request flow: TCP bytes -> `Deserializer` (RESP parsing) -> `Vec<String>` -> `Request::try_from` -> `Request::execute(&Db)` -> `Response::serialize` -> bytes.
+
+`main.rs` owns the listener and a background tokio task that runs `db::remove_expired_entries` on a random sample (active expiration). Passive expiration happens inside command execution: each command checks `Object::is_expired()` and removes the entry before acting.
+
+`Db = Arc<Mutex<IndexMap<String, Object>>>`. `IndexMap` is required so the active-expiration sampler can index randomly. `Object { value: Value, expiration: Option<SystemTime> }` where `Value` is an enum of `Integer(i64) | String(String) | List(VecDeque<String>)`. Mutex is `std::sync::Mutex` (not tokio's) since it is never held across `await`.
+
+### Command module layout
+
+Commands are grouped by family. Each family has a parser and an execution module:
+
+- `cmd/types.rs`: lowercase command-name string constants
+- `cmd/request.rs`: `Request` enum, `TryFrom<Vec<String>>` dispatch, and `execute(&Db) -> Response`
+- `cmd/parser/<family>.rs`: parses `&[String]` args into a typed struct (e.g. `arithmetic::Integer`, `list::List`, `set::Set`)
+- `cmd/execution/<family>.rs`: enum variant per command in the family + a shared `execute` that takes the parsed inputs; uses an `operation` method returning a closure (`Box<dyn Fn ...>`) selected per variant
+
+To add a new command in an existing family: add the constant in `types.rs`, add the variant in the execution enum (and its closure in `operation`), wire a `Request` variant + `try_from` arm + `execute` arm. Tests live in `#[cfg(test)] mod tests` inside each touched file.
+
+### Known shape quirks
+
+- `arithmetic::Integer::parse` and `list::List::parse` hardcode their command name (`INCRBY` / `LPUSH`) in the `WrongNumberOfArguments` error, so error messages can be misleading when called for sibling commands (`DECRBY`, `RPUSH`). Parameterizing this is a tracked TODO in `JOURNAL.md`.
+- `Request::try_from` and the family parsers both validate arity. The request-level check covers the "no key" case, the parser covers "no values".

--- a/src/cmd/execution/list.rs
+++ b/src/cmd/execution/list.rs
@@ -7,8 +7,11 @@ use crate::{
     db::{Db, Object, Value},
 };
 
+type PushOp = Box<dyn Fn(&mut VecDeque<String>, String)>;
+
 pub enum List {
     LPush,
+    RPush,
 }
 
 impl List {
@@ -44,9 +47,10 @@ impl List {
         }
     }
 
-    pub fn operation(&self) -> Box<dyn Fn(&mut VecDeque<String>, String)> {
+    pub fn operation(&self) -> PushOp {
         match self {
             List::LPush => Box::new(|l, v| l.push_front(v)),
+            List::RPush => Box::new(|l, v| l.push_back(v)),
         }
     }
 }
@@ -147,6 +151,82 @@ mod tests {
     fn lpush_empty_string_element() {
         let db = empty_db();
         let result = List::LPush.execute(&db, "k".into(), vec!["".into()]);
+        assert_eq!(result, Ok(1));
+        assert_list(&db, "k", &[""]);
+    }
+
+    #[test]
+    fn rpush_new_key_single() {
+        let db = empty_db();
+        let result = List::RPush.execute(&db, "k".into(), vec!["v".into()]);
+        assert_eq!(result, Ok(1));
+        assert_list(&db, "k", &["v"]);
+    }
+
+    #[test]
+    fn rpush_new_key_multiple() {
+        let db = empty_db();
+        let result = List::RPush.execute(
+            &db,
+            "k".into(),
+            vec!["a".into(), "b".into(), "c".into()],
+        );
+        assert_eq!(result, Ok(3));
+        assert_list(&db, "k", &["a", "b", "c"]);
+    }
+
+    #[test]
+    fn rpush_existing_list() {
+        let db = empty_db();
+        db.lock().unwrap().insert(
+            "k".into(),
+            Object::new(Value::List(VecDeque::from(vec!["x".to_string()])), None),
+        );
+        let result = List::RPush.execute(&db, "k".into(), vec!["a".into(), "b".into()]);
+        assert_eq!(result, Ok(3));
+        assert_list(&db, "k", &["x", "a", "b"]);
+    }
+
+    #[test]
+    fn rpush_wrong_type_string() {
+        let db = empty_db();
+        db.lock().unwrap().insert(
+            "k".into(),
+            Object::new(Value::String("foo".into()), None),
+        );
+        let result = List::RPush.execute(&db, "k".into(), vec!["v".into()]);
+        assert_eq!(result, Err(ClientError::WrongType));
+    }
+
+    #[test]
+    fn rpush_wrong_type_integer() {
+        let db = empty_db();
+        db.lock()
+            .unwrap()
+            .insert("k".into(), Object::new(Value::Integer(5), None));
+        let result = List::RPush.execute(&db, "k".into(), vec!["v".into()]);
+        assert_eq!(result, Err(ClientError::WrongType));
+    }
+
+    #[test]
+    fn rpush_expired_key() {
+        let db = empty_db();
+        db.lock().unwrap().insert(
+            "k".into(),
+            Object::new(
+                Value::List(VecDeque::from(vec!["old".to_string()])),
+                Some(SystemTime::now() - Duration::from_secs(10)),
+            ),
+        );
+        let result = List::RPush.execute(&db, "k".into(), vec!["new".into()]);
+        assert_eq!(result, Ok(1));
+        assert_list(&db, "k", &["new"]);
+    }
+
+    #[test]
+    fn rpush_empty_string_element() {
+        let db = empty_db();
+        let result = List::RPush.execute(&db, "k".into(), vec!["".into()]);
         assert_eq!(result, Ok(1));
         assert_list(&db, "k", &[""]);
     }

--- a/src/cmd/request.rs
+++ b/src/cmd/request.rs
@@ -6,7 +6,7 @@ use crate::{
             arithmetic::Integer as IntegerParser, list::List as ListParser, set::Set as SetParser,
         },
         response::Response,
-        types::{DECR, DECRBY, DEL, ECHO, EXISTS, GET, INCR, INCRBY, LPUSH, PING, SET},
+        types::{DECR, DECRBY, DEL, ECHO, EXISTS, GET, INCR, INCRBY, LPUSH, PING, RPUSH, SET},
     },
     db::{Db, Object},
 };
@@ -24,6 +24,7 @@ pub enum Request {
     IncrBy(IntegerParser),
     DecrBy(IntegerParser),
     LPush(ListParser),
+    RPush(ListParser),
 }
 
 impl Request {
@@ -127,6 +128,13 @@ impl Request {
                     |e| Response::SimpleError(e.to_string()),
                     |v| Response::Integer(v.to_string()),
                 ),
+
+            Self::RPush(parser) => List::RPush
+                .execute(db, parser.key, parser.values)
+                .map_or_else(
+                    |e| Response::SimpleError(e.to_string()),
+                    |v| Response::Integer(v.to_string()),
+                ),
         }
     }
 }
@@ -225,6 +233,14 @@ impl TryFrom<Vec<String>> for Request {
                     Err(ClientError::WrongNumberOfArguments(LPUSH.to_string()))
                 } else {
                     Ok(ListParser::parse(&params[1..]).map(Request::LPush)?)
+                }
+            }
+
+            RPUSH => {
+                if params.len() == 1 {
+                    Err(ClientError::WrongNumberOfArguments(RPUSH.to_string()))
+                } else {
+                    Ok(ListParser::parse(&params[1..]).map(Request::RPush)?)
                 }
             }
 
@@ -867,6 +883,60 @@ mod tests {
             Object::new(Value::String("foo".to_string()), None),
         );
         let cmd = Request::LPush(ListParser {
+            key: "k".to_string(),
+            values: vec!["v".to_string()],
+        });
+        let reply = cmd.execute(&db);
+        assert!(matches!(reply, Response::SimpleError(_)));
+    }
+
+    #[test]
+    fn rpush_no_args() {
+        let params = vec![RPUSH.to_string()];
+        let cmd = Request::try_from(params);
+        assert_eq!(
+            cmd.unwrap_err(),
+            ClientError::WrongNumberOfArguments(RPUSH.to_string())
+        );
+    }
+
+    #[test]
+    fn rpush_ok() {
+        let params = vec![
+            RPUSH.to_string(),
+            "k".to_string(),
+            "a".to_string(),
+            "b".to_string(),
+        ];
+        let cmd = Request::try_from(params);
+        assert_eq!(
+            cmd.unwrap(),
+            Request::RPush(ListParser {
+                key: "k".to_string(),
+                values: vec!["a".to_string(), "b".to_string()],
+            })
+        );
+    }
+
+    #[test]
+    fn execute_rpush_ok() {
+        let db = Db::new(Mutex::new(IndexMap::new()));
+        let cmd = Request::RPush(ListParser {
+            key: "k".to_string(),
+            values: vec!["a".to_string(), "b".to_string()],
+        });
+        let reply = cmd.execute(&db);
+        assert_eq!(reply, Response::Integer("2".to_string()));
+    }
+
+    #[test]
+    fn execute_rpush_err() {
+        let db = Db::new(Mutex::new(IndexMap::new()));
+        db.lock().unwrap().insert(
+            "k".to_string(),
+            Object::new(Value::String("foo".to_string()), None),
+        );
+        let cmd = Request::RPush(ListParser {
             key: "k".to_string(),
             values: vec!["v".to_string()],
         });

--- a/src/cmd/types.rs
+++ b/src/cmd/types.rs
@@ -9,3 +9,4 @@ pub const DECR: &str = "decr";
 pub const INCRBY: &str = "incrby";
 pub const DECRBY: &str = "decrby";
 pub const LPUSH: &str = "lpush";
+pub const RPUSH: &str = "rpush";


### PR DESCRIPTION
## Summary
- implement RPUSH mirroring LPUSH (parser shared, new `RPush` variant in execution + request, push_back op)
- extract `PushOp` type alias to silence clippy `type_complexity`
- add CLAUDE.md (release-mode default, architecture overview, command-family layout)

## Test plan
- [x] cargo test --release (158 passing)
- [x] cargo clippy --release (clean)
- [x] manual: redis-cli RPUSH on a fresh key, existing list, wrong-type key, expired key

🤖 Generated with [Claude Code](https://claude.com/claude-code)